### PR TITLE
Fix month/week view tasks

### DIFF
--- a/TimeController/TimeController/ViewModels/MonthViewModel.cs
+++ b/TimeController/TimeController/ViewModels/MonthViewModel.cs
@@ -191,8 +191,8 @@ namespace TimeController.ViewModels
             if (dialog.ShowDialog() == true && dialog.ResultTask != null)
             {
                 dialog.ResultTask.Mode = TaskMode.Strong;
+                // 保存任务后将通过 TaskSaved 事件自动添加到字典
                 await _taskService.UpdateTaskAsync(dialog.ResultTask);
-                AddTaskToDictionary(dialog.ResultTask);
             }
         }
 

--- a/TimeController/TimeController/ViewModels/WeekViewModel.cs
+++ b/TimeController/TimeController/ViewModels/WeekViewModel.cs
@@ -30,6 +30,7 @@ namespace TimeController.ViewModels
         public event Action<TaskModel>? SaveRequested;
 
         public ICommand RemoveTaskBlockCommand { get; }
+        public ICommand MarkCompletedCommand { get; }
         public ICollectionView TimedTaskBlocksView { get; }
 
         public WeekViewModel(ITaskService taskService)
@@ -51,6 +52,7 @@ namespace TimeController.ViewModels
             };
             SaveRequested += OnTaskSaved;
             RemoveTaskBlockCommand = new RelayCommand<TaskBlock>(RemoveTaskBlock);
+            MarkCompletedCommand = new RelayCommand<TaskBlock>(MarkTaskCompleted);
             _currentDate = DateTime.Today;
             UpdateMonthText();
             UpdateWeekText();
@@ -126,7 +128,8 @@ namespace TimeController.ViewModels
                 Row = task.StartTime.HasValue ? task.StartTime.Value.Hours : 0,
                 RowSpan = (!task.IsAllDay && task.StartTime.HasValue && task.EndTime.HasValue)
                           ? Math.Max(1, (int)(task.EndTime.Value - task.StartTime.Value).TotalHours)+1 : 1,
-                Id = task.Id
+                Id = task.Id,
+                IsCompleted = task.Status == MyTaskStatus.Completed
             };
 
             TaskBlocks.Add(taskBlock);
@@ -252,6 +255,7 @@ namespace TimeController.ViewModels
             public TimeSpan EndTime { get; set; }
             public Brush Brush { get; set; }
             public bool IsAllDay { get; set; }
+            public bool IsCompleted { get; set; }
 
             // 定位属性
             public int Column { get; set; } // 星期几（0=周一，1=周二...）
@@ -312,6 +316,7 @@ namespace TimeController.ViewModels
             SaveRequested += OnTaskSaved;
             LoadTasksForCurrentWeek();
             RemoveTaskBlockCommand = new RelayCommand<TaskBlock>(RemoveTaskBlock);
+            MarkCompletedCommand = new RelayCommand<TaskBlock>(MarkTaskCompleted);
         }
 
 
@@ -333,6 +338,20 @@ namespace TimeController.ViewModels
             }
             OnPropertyChanged(nameof(TimedTaskBlocks));
             TimedTaskBlocksView.Refresh(); // 强制刷新视图
+        }
+
+        private async void MarkTaskCompleted(TaskBlock block)
+        {
+            if (block == null) return;
+            var task = Tasks.FirstOrDefault(t => t.Id == block.Id);
+            if (task != null)
+            {
+                task.Status = MyTaskStatus.Completed;
+                task.IsCompleted = true;
+                if (_taskService != null)
+                    await _taskService.UpdateTaskAsync(task);
+            }
+            LoadTasksForCurrentWeek();
         }
 
 

--- a/TimeController/TimeController/Views/StrongGoalMonth/DateCard.xaml
+++ b/TimeController/TimeController/Views/StrongGoalMonth/DateCard.xaml
@@ -45,8 +45,8 @@
                       Margin="0,5,0,0"
                       FontSize="20"/>
 
-            <ItemsControl Grid.Row="1"
-                          VerticalAlignment="Center"
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Height="60">
+                <ItemsControl
                           ItemsSource="{Binding DisplayedTasks, RelativeSource={RelativeSource AncestorType=UserControl}}">
                 
                 <ItemsControl.ItemContainerStyle>
@@ -68,7 +68,8 @@
                                    ToolTip="{Binding Name}"/>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
-            </ItemsControl>
+                </ItemsControl>
+            </ScrollViewer>
             <Button Grid.Row="2"
                     Margin="0,2,0,2"
                     Background="Transparent"
@@ -96,7 +97,8 @@
            VerticalOffset="8"
            AllowsTransparency="True"
            StaysOpen="False"
-           PopupAnimation="Fade">
+           PopupAnimation="Fade"
+           Closed="TaskPopup_Closed">
                 <Border Background="#CCFFFFFF"
                 CornerRadius="6"
                 Padding="8">

--- a/TimeController/TimeController/Views/StrongGoalWeek/WeekView.xaml
+++ b/TimeController/TimeController/Views/StrongGoalWeek/WeekView.xaml
@@ -92,8 +92,8 @@
                         </StackPanel>
 
                         <!-- 全天任务列表 -->
-                        <ItemsControl Grid.Row="1" Margin="2" 
-                                      ItemsSource="{Binding AllDayTaskBlocks}">
+                        <ScrollViewer Grid.Row="1" Margin="2" VerticalScrollBarVisibility="Auto" Height="90">
+                            <ItemsControl ItemsSource="{Binding AllDayTaskBlocks}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Vertical"/>
@@ -101,17 +101,29 @@
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="{Binding Brush}" 
-                                            CornerRadius="6" 
-                                            Margin="2"
-                                            Padding="6,2"
-                                            MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
-                                        <TextBlock Text="{Binding Name}" 
-                                                   FontWeight="Bold"
-                                                   Foreground="Black"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding Note}" />
-                                    </Border>
+                                    <Grid MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" Tag="{Binding}">
+                                        <Border Background="{Binding Brush}"
+                                                CornerRadius="6"
+                                                Margin="2"
+                                                Padding="6,2"
+                                                MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
+                                            <Grid>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="Black" TextTrimming="CharacterEllipsis" ToolTip="{Binding Note}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                                <Button x:Name="CompleteButton" Content="✔" Width="16" Height="16" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2,2,22,0" Background="Transparent" BorderThickness="0" Foreground="Green" Visibility="Collapsed" Command="{Binding DataContext.MarkCompletedCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                            </Grid>
+                                        </Border>
+                                    </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                             <ItemsControl.ItemContainerStyle>
@@ -120,7 +132,8 @@
                                             Value="{Binding Column, Converter={StaticResource ColumnToVisibilityConverter}, ConverterParameter=0}"/>
                                 </Style>
                             </ItemsControl.ItemContainerStyle>
-                        </ItemsControl>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
 
@@ -143,8 +156,8 @@
                         </StackPanel>
 
                         <!-- 全天任务列表 -->
-                        <ItemsControl Grid.Row="1" Margin="2" 
-                                      ItemsSource="{Binding AllDayTaskBlocks}">
+                        <ScrollViewer Grid.Row="1" Margin="2" VerticalScrollBarVisibility="Auto" Height="90">
+                            <ItemsControl ItemsSource="{Binding AllDayTaskBlocks}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Vertical"/>
@@ -152,17 +165,29 @@
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="{Binding Brush}" 
-                                            CornerRadius="6" 
-                                            Margin="2"
-                                            Padding="6,2"
-                                            MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
-                                        <TextBlock Text="{Binding Name}" 
-                                                   FontWeight="Bold"
-                                                   Foreground="Black"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding Note}" />
-                                    </Border>
+                                    <Grid MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" Tag="{Binding}">
+                                        <Border Background="{Binding Brush}"
+                                                CornerRadius="6"
+                                                Margin="2"
+                                                Padding="6,2"
+                                                MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
+                                            <Grid>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="Black" TextTrimming="CharacterEllipsis" ToolTip="{Binding Note}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                                <Button x:Name="CompleteButton" Content="✔" Width="16" Height="16" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2,2,22,0" Background="Transparent" BorderThickness="0" Foreground="Green" Visibility="Collapsed" Command="{Binding DataContext.MarkCompletedCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                            </Grid>
+                                        </Border>
+                                    </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                             <ItemsControl.ItemContainerStyle>
@@ -171,7 +196,8 @@
                                             Value="{Binding Column, Converter={StaticResource ColumnToVisibilityConverter}, ConverterParameter=1}"/>
                                 </Style>
                             </ItemsControl.ItemContainerStyle>
-                        </ItemsControl>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
 
@@ -194,8 +220,8 @@
                         </StackPanel>
 
                         <!-- 全天任务列表 -->
-                        <ItemsControl Grid.Row="1" Margin="2" 
-                                      ItemsSource="{Binding AllDayTaskBlocks}">
+                        <ScrollViewer Grid.Row="1" Margin="2" VerticalScrollBarVisibility="Auto" Height="90">
+                            <ItemsControl ItemsSource="{Binding AllDayTaskBlocks}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Vertical"/>
@@ -203,17 +229,29 @@
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="{Binding Brush}" 
-                                            CornerRadius="6" 
-                                            Margin="2"
-                                            Padding="6,2"
-                                            MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
-                                        <TextBlock Text="{Binding Name}" 
-                                                   FontWeight="Bold"
-                                                   Foreground="Black"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding Note}" />
-                                    </Border>
+                                    <Grid MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" Tag="{Binding}">
+                                        <Border Background="{Binding Brush}"
+                                                CornerRadius="6"
+                                                Margin="2"
+                                                Padding="6,2"
+                                                MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
+                                            <Grid>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="Black" TextTrimming="CharacterEllipsis" ToolTip="{Binding Note}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                                <Button x:Name="CompleteButton" Content="✔" Width="16" Height="16" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2,2,22,0" Background="Transparent" BorderThickness="0" Foreground="Green" Visibility="Collapsed" Command="{Binding DataContext.MarkCompletedCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                            </Grid>
+                                        </Border>
+                                    </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                             <ItemsControl.ItemContainerStyle>
@@ -222,7 +260,8 @@
                                             Value="{Binding Column, Converter={StaticResource ColumnToVisibilityConverter}, ConverterParameter=2}"/>
                                 </Style>
                             </ItemsControl.ItemContainerStyle>
-                        </ItemsControl>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
 
@@ -244,8 +283,8 @@
                         </StackPanel>
 
                         <!-- 全天任务列表 -->
-                        <ItemsControl Grid.Row="1" Margin="2" 
-                                      ItemsSource="{Binding AllDayTaskBlocks}">
+                        <ScrollViewer Grid.Row="1" Margin="2" VerticalScrollBarVisibility="Auto" Height="90">
+                            <ItemsControl ItemsSource="{Binding AllDayTaskBlocks}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Vertical"/>
@@ -253,17 +292,29 @@
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="{Binding Brush}" 
-                                            CornerRadius="6" 
-                                            Margin="2"
-                                            Padding="6,2"
-                                            MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
-                                        <TextBlock Text="{Binding Name}" 
-                                                   FontWeight="Bold"
-                                                   Foreground="Black"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding Note}" />
-                                    </Border>
+                                    <Grid MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" Tag="{Binding}">
+                                        <Border Background="{Binding Brush}"
+                                                CornerRadius="6"
+                                                Margin="2"
+                                                Padding="6,2"
+                                                MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
+                                            <Grid>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="Black" TextTrimming="CharacterEllipsis" ToolTip="{Binding Note}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                                <Button x:Name="CompleteButton" Content="✔" Width="16" Height="16" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2,2,22,0" Background="Transparent" BorderThickness="0" Foreground="Green" Visibility="Collapsed" Command="{Binding DataContext.MarkCompletedCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                            </Grid>
+                                        </Border>
+                                    </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                             <ItemsControl.ItemContainerStyle>
@@ -272,7 +323,8 @@
                                             Value="{Binding Column, Converter={StaticResource ColumnToVisibilityConverter}, ConverterParameter=3}"/>
                                 </Style>
                             </ItemsControl.ItemContainerStyle>
-                        </ItemsControl>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
 
@@ -294,8 +346,8 @@
                         </StackPanel>
 
                         <!-- 全天任务列表 -->
-                        <ItemsControl Grid.Row="1" Margin="2" 
-                                      ItemsSource="{Binding AllDayTaskBlocks}">
+                        <ScrollViewer Grid.Row="1" Margin="2" VerticalScrollBarVisibility="Auto" Height="90">
+                            <ItemsControl ItemsSource="{Binding AllDayTaskBlocks}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Vertical"/>
@@ -303,17 +355,29 @@
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="{Binding Brush}" 
-                                            CornerRadius="6" 
-                                            Margin="2"
-                                            Padding="6,2"
-                                            MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
-                                        <TextBlock Text="{Binding Name}" 
-                                                   FontWeight="Bold"
-                                                   Foreground="Black"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding Note}" />
-                                    </Border>
+                                    <Grid MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" Tag="{Binding}">
+                                        <Border Background="{Binding Brush}"
+                                                CornerRadius="6"
+                                                Margin="2"
+                                                Padding="6,2"
+                                                MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
+                                            <Grid>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="Black" TextTrimming="CharacterEllipsis" ToolTip="{Binding Note}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                                <Button x:Name="CompleteButton" Content="✔" Width="16" Height="16" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2,2,22,0" Background="Transparent" BorderThickness="0" Foreground="Green" Visibility="Collapsed" Command="{Binding DataContext.MarkCompletedCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                            </Grid>
+                                        </Border>
+                                    </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                             <ItemsControl.ItemContainerStyle>
@@ -322,7 +386,8 @@
                                             Value="{Binding Column, Converter={StaticResource ColumnToVisibilityConverter}, ConverterParameter=4}"/>
                                 </Style>
                             </ItemsControl.ItemContainerStyle>
-                        </ItemsControl>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
 
@@ -344,8 +409,8 @@
                         </StackPanel>
 
                         <!-- 全天任务列表 -->
-                        <ItemsControl Grid.Row="1" Margin="2" 
-                                      ItemsSource="{Binding AllDayTaskBlocks}">
+                        <ScrollViewer Grid.Row="1" Margin="2" VerticalScrollBarVisibility="Auto" Height="90">
+                            <ItemsControl ItemsSource="{Binding AllDayTaskBlocks}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Vertical"/>
@@ -353,17 +418,29 @@
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="{Binding Brush}" 
-                                            CornerRadius="6" 
-                                            Margin="2"
-                                            Padding="6,2"
-                                            MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
-                                        <TextBlock Text="{Binding Name}" 
-                                                   FontWeight="Bold"
-                                                   Foreground="Black"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding Note}" />
-                                    </Border>
+                                    <Grid MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" Tag="{Binding}">
+                                        <Border Background="{Binding Brush}"
+                                                CornerRadius="6"
+                                                Margin="2"
+                                                Padding="6,2"
+                                                MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
+                                            <Grid>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="Black" TextTrimming="CharacterEllipsis" ToolTip="{Binding Note}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                                <Button x:Name="CompleteButton" Content="✔" Width="16" Height="16" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2,2,22,0" Background="Transparent" BorderThickness="0" Foreground="Green" Visibility="Collapsed" Command="{Binding DataContext.MarkCompletedCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                            </Grid>
+                                        </Border>
+                                    </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                             <ItemsControl.ItemContainerStyle>
@@ -372,7 +449,8 @@
                                             Value="{Binding Column, Converter={StaticResource ColumnToVisibilityConverter}, ConverterParameter=5}"/>
                                 </Style>
                             </ItemsControl.ItemContainerStyle>
-                        </ItemsControl>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
 
@@ -394,8 +472,8 @@
                         </StackPanel>
 
                         <!-- 全天任务列表 -->
-                        <ItemsControl Grid.Row="1" Margin="2" 
-                                      ItemsSource="{Binding AllDayTaskBlocks}">
+                        <ScrollViewer Grid.Row="1" Margin="2" VerticalScrollBarVisibility="Auto" Height="90">
+                            <ItemsControl ItemsSource="{Binding AllDayTaskBlocks}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Vertical"/>
@@ -403,17 +481,29 @@
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border Background="{Binding Brush}" 
-                                            CornerRadius="6" 
-                                            Margin="2"
-                                            Padding="6,2"
-                                            MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
-                                        <TextBlock Text="{Binding Name}" 
-                                                   FontWeight="Bold"
-                                                   Foreground="Black"
-                                                   TextTrimming="CharacterEllipsis"
-                                                   ToolTip="{Binding Note}" />
-                                    </Border>
+                                    <Grid MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" Tag="{Binding}">
+                                        <Border Background="{Binding Brush}"
+                                                CornerRadius="6"
+                                                Margin="2"
+                                                Padding="6,2"
+                                                MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
+                                            <Grid>
+                                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="Black" TextTrimming="CharacterEllipsis" ToolTip="{Binding Note}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                                <Button x:Name="CompleteButton" Content="✔" Width="16" Height="16" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2,2,22,0" Background="Transparent" BorderThickness="0" Foreground="Green" Visibility="Collapsed" Command="{Binding DataContext.MarkCompletedCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
+                                            </Grid>
+                                        </Border>
+                                    </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                             <ItemsControl.ItemContainerStyle>
@@ -422,7 +512,8 @@
                                             Value="{Binding Column, Converter={StaticResource ColumnToVisibilityConverter}, ConverterParameter=6}"/>
                                 </Style>
                             </ItemsControl.ItemContainerStyle>
-                        </ItemsControl>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </Grid>
                 </Border>
 
@@ -677,27 +768,27 @@
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
                                     <Grid MouseEnter="Grid_MouseEnter" MouseLeave="Grid_MouseLeave" Tag="{Binding}">
-                                        <Border Background="{Binding Brush}" CornerRadius="3" Margin="2"
-                              MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
+                                        <Border Background="{Binding Brush}" CornerRadius="3" Margin="2" MouseLeftButtonDown="TaskBlock_MouseLeftButtonDown">
                                             <Grid>
                                                 <!-- 任务内容 -->
-                                                <TextBlock Text="{Binding Name}" Margin="5" TextWrapping="Wrap"/>
+                                                <TextBlock Text="{Binding Name}" Margin="5" TextWrapping="Wrap">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                                                    <Setter Property="Foreground" Value="Gray"/>
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+
+                                                <!-- 完成按钮 -->
+                                                <Button x:Name="CompleteButton" Content="✔" Width="20" Height="20" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2,2,24,0" Background="Transparent" BorderThickness="0" Foreground="Green" Visibility="Collapsed" Command="{Binding DataContext.MarkCompletedCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
 
                                                 <!-- 删除按钮（叉号） -->
-                                                <Button x:Name="DeleteButton"
-                                      Content="✕" 
-                                      Width="20" Height="20" 
-                                      HorizontalAlignment="Right" 
-                                      VerticalAlignment="Top" 
-                                      Margin="2"
-                                      Background="Transparent"
-                                      BorderThickness="0"
-                                      Foreground="Red"
-                                      FontWeight="Bold"
-                                      Visibility="Collapsed"
-                                      Command="{Binding DataContext.RemoveTaskBlockCommand, 
-                                              RelativeSource={RelativeSource AncestorType=ItemsControl}}"
-                                      CommandParameter="{Binding}"/>
+                                                <Button x:Name="DeleteButton" Content="✕" Width="20" Height="20" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="2" Background="Transparent" BorderThickness="0" Foreground="Red" FontWeight="Bold" Visibility="Collapsed" Command="{Binding DataContext.RemoveTaskBlockCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}"/>
                                             </Grid>
                                         </Border>
                                     </Grid>

--- a/TimeController/TimeController/Views/StrongGoalWeek/WeekView.xaml.cs
+++ b/TimeController/TimeController/Views/StrongGoalWeek/WeekView.xaml.cs
@@ -312,9 +312,12 @@ namespace TimeController.Views.StrongGoalWeek
         {
             if (sender is Grid grid)
             {
-                var button = grid.FindName("DeleteButton") as Button;
-                if (button != null)
-                    button.Visibility = Visibility.Visible;
+                var del = grid.FindName("DeleteButton") as Button;
+                if (del != null)
+                    del.Visibility = Visibility.Visible;
+                var complete = grid.FindName("CompleteButton") as Button;
+                if (complete != null)
+                    complete.Visibility = Visibility.Visible;
             }
         }
 
@@ -323,9 +326,12 @@ namespace TimeController.Views.StrongGoalWeek
         {
             if (sender is Grid grid)
             {
-                var button = grid.FindName("DeleteButton") as Button;
-                if (button != null)
-                    button.Visibility = Visibility.Collapsed;
+                var del = grid.FindName("DeleteButton") as Button;
+                if (del != null)
+                    del.Visibility = Visibility.Collapsed;
+                var complete = grid.FindName("CompleteButton") as Button;
+                if (complete != null)
+                    complete.Visibility = Visibility.Collapsed;
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid duplicate tasks in month view by relying on TaskSaved event
- add completion support in week view and show buttons on hover
- allow scrolling for week view all-day tasks
- keep month view card height stable and close popup correctly

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684403f844cc832fbb8753de79fbb003