### PR TITLE
Implement dark theme resources and init

### DIFF
--- a/TimeController/TimeController/App.xaml.cs
+++ b/TimeController/TimeController/App.xaml.cs
@@ -15,6 +15,7 @@ using TimeController.Views.StrongGoalMonth;
 using TimeController.Views.StrongGoalWeek;
 using iNKORE.UI.WPF.Modern.Helpers.Styles;
 using MessageBox = iNKORE.UI.WPF.Modern.Controls.MessageBox;
+using TimeController.Helpers;
 
 namespace TimeController
 {
@@ -84,6 +85,10 @@ namespace TimeController
                 })
                 .Build();
             AppHost.Start();
+
+            // 根据存储的主题选项或系统主题应用样式
+            var settingsSvc = AppHost.Services.GetRequiredService<ISettingsService>();
+            ThemeHelper.ApplyFromSettings(settingsSvc);
 
             // 确保数据库使用迁移初始化
             try

--- a/TimeController/TimeController/Helpers/ThemeHelper.cs
+++ b/TimeController/TimeController/Helpers/ThemeHelper.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Windows;
+using Microsoft.Win32;
+using TimeController.Services;
+
+namespace TimeController.Helpers
+{
+    public static class ThemeHelper
+    {
+        public static void ApplyAppTheme(bool isLight)
+        {
+            var uri = new Uri($"/TimeController;component/Themes/{(isLight ? "Light" : "Dark") }Theme.xaml", UriKind.Relative);
+            var dict = new ResourceDictionary { Source = uri };
+            Application.Current.Resources.MergedDictionaries[0] = dict;
+        }
+
+        public static bool GetSystemIsLight()
+        {
+            const string key = @"HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+            var value = Registry.GetValue(key, "AppsUseLightTheme", 1);
+            return Convert.ToInt32(value) == 1;
+        }
+
+        public static void ApplyFromSettings(ISettingsService settings)
+        {
+            var opt = settings.LoadThemeOption();
+            if (opt == ThemeOption.System)
+            {
+                ApplyAppTheme(GetSystemIsLight());
+            }
+            else
+            {
+                ApplyAppTheme(opt == ThemeOption.Light);
+            }
+        }
+    }
+}

--- a/TimeController/TimeController/Themes/DarkTheme.xaml
+++ b/TimeController/TimeController/Themes/DarkTheme.xaml
@@ -7,6 +7,18 @@
     <!-- 覆盖的深色自定义 -->
     <SolidColorBrush x:Key="AppBackgroundBrush" Color="#111111"/>
     <SolidColorBrush x:Key="AppForegroundBrush" Color="White"/>
-    <!-- … -->
+
+    <SolidColorBrush x:Key="NavigationBackgroundBrush" Color="#18171d"/>
+    <SolidColorBrush x:Key="PageBackgroundBrush" Color="#222328"/>
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#e0e0e0"/>
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#a0a0a0"/>
+    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#2a2a33"/>
+    <SolidColorBrush x:Key="ButtonHoverBrush" Color="#3a3a44"/>
+    <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#ffffff"/>
+    <SolidColorBrush x:Key="InputBorderBrush" Color="#44444f"/>
+    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="#64646f"/>
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="#1f1f27"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#1a1a1f"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#5a9bd4"/>
 
 </ResourceDictionary>

--- a/TimeController/TimeController/Themes/LightTheme.xaml
+++ b/TimeController/TimeController/Themes/LightTheme.xaml
@@ -7,5 +7,16 @@
     <SolidColorBrush x:Key="AppBackgroundBrush" Color="White"/>
     <SolidColorBrush x:Key="AppForegroundBrush" Color="Black"/>
 
-
+    <SolidColorBrush x:Key="NavigationBackgroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="PageBackgroundBrush" Color="#F5F5F5"/>
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="#333333"/>
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#666666"/>
+    <SolidColorBrush x:Key="ButtonBackgroundBrush" Color="#E5E5E5"/>
+    <SolidColorBrush x:Key="ButtonHoverBrush" Color="#D5D5D5"/>
+    <SolidColorBrush x:Key="ButtonForegroundBrush" Color="#000000"/>
+    <SolidColorBrush x:Key="InputBorderBrush" Color="#CCCCCC"/>
+    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="#888888"/>
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="DividerBrush" Color="#E0E0E0"/>
+    <SolidColorBrush x:Key="AccentBrush" Color="#5a9bd4"/>
 </ResourceDictionary>

--- a/TimeController/TimeController/ViewModels/SettingsPageViewModel.cs
+++ b/TimeController/TimeController/ViewModels/SettingsPageViewModel.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows;
-using Microsoft.Win32;
+using TimeController.Helpers;
 using System.Windows.Input;
 using TimeController.Services;
 using TimeController.Models;
@@ -48,7 +48,7 @@ namespace TimeController.ViewModels
             if (_selectedThemeOption == ThemeOption.System)
                 SubscribeSystemThemeChange();
             else
-                ApplyAppTheme(_selectedThemeOption == ThemeOption.Light);
+                ThemeHelper.ApplyAppTheme(_selectedThemeOption == ThemeOption.Light);
 
             // 从存储中读取阈值，默认至少 4
             RewardThreshold = Math.Max(4, _settingsService.LoadWeeklyTarget());
@@ -139,7 +139,7 @@ namespace TimeController.ViewModels
                 else
                 {
                     UnsubscribeSystemThemeChange();
-                    ApplyAppTheme(value == ThemeOption.Light);
+                    ThemeHelper.ApplyAppTheme(value == ThemeOption.Light);
                 }
             }
         }
@@ -151,7 +151,7 @@ namespace TimeController.ViewModels
         {
             SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
             // 首次同步一次
-            ApplyAppTheme(GetCurrentSystemIsLight());
+            ThemeHelper.ApplyAppTheme(ThemeHelper.GetSystemIsLight());
         }
 
         private void UnsubscribeSystemThemeChange()
@@ -163,25 +163,12 @@ namespace TimeController.ViewModels
         {
             // Windows 主题改变时 e.Category 为 General
             if (e.Category == UserPreferenceCategory.General)
-                ApplyAppTheme(GetCurrentSystemIsLight());
+                ThemeHelper.ApplyAppTheme(ThemeHelper.GetSystemIsLight());
         }
 
-        private bool GetCurrentSystemIsLight()
-        {
-            const string key = @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
-            var value = Registry.GetValue(key, "AppsUseLightTheme", 1);
-            return Convert.ToInt32(value) == 1;
-        }
+        private bool GetCurrentSystemIsLight() => ThemeHelper.GetSystemIsLight();
 
-        private void ApplyAppTheme(bool isLight)
-        {
-            // 假设你项目里有两个 ResourceDictionary：LightTheme.xaml / DarkTheme.xaml
-            var uri = new Uri($"/TimeController;component/Themes/{(isLight ? "Light" : "Dark")}Theme.xaml",
-                              UriKind.Relative);
-            var dict = new ResourceDictionary { Source = uri };
-            // 替换第一个 MergedDictionary
-            Application.Current.Resources.MergedDictionaries[0] = dict;
-        }
+        private void ApplyAppTheme(bool isLight) => ThemeHelper.ApplyAppTheme(isLight);
 
         #endregion
 

--- a/TimeController/TimeController/Views/Navigation/ShellView.xaml
+++ b/TimeController/TimeController/Views/Navigation/ShellView.xaml
@@ -15,7 +15,10 @@
         IsPaneToggleButtonVisible="False"
         IsBackButtonVisible="Collapsed"
         SelectionChanged="NavigationView_SelectionChanged"
-        AlwaysShowHeader="False">
+        AlwaysShowHeader="False"
+        Background="{DynamicResource NavigationBackgroundBrush}"
+        PaneBackground="{DynamicResource NavigationBackgroundBrush}"
+        Foreground="{DynamicResource PrimaryTextBrush}">
 
         <FrameworkElement.Resources>
             <SolidColorBrush x:Key="{x:Static ui:ThemeKeys.NavigationViewContentBackgroundKey}" Color="Transparent"/>

--- a/TimeController/TimeController/Views/SettingsInfo/SettingsPage.xaml
+++ b/TimeController/TimeController/Views/SettingsInfo/SettingsPage.xaml
@@ -1,27 +1,21 @@
-﻿<ui:Page x:Class="TimeController.Views.SettingsInfo.SettingsPage"
+<ui:Page x:Class="TimeController.Views.SettingsInfo.SettingsPage"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern" 
+             xmlns:ui="http://schemas.inkore.net/lib/ui/wpf/modern"
              xmlns:ikw="http://schemas.inkore.net/lib/ui/wpf"
             xmlns:local="clr-namespace:TimeController.Services"
-
->
+            Background="{DynamicResource PageBackgroundBrush}"
+            Foreground="{DynamicResource PrimaryTextBrush}">
 
     <ui:Page.Resources>
         <!-- 基于系统 AccentButtonStyleKey 创建一个自定义保存按钮样式 -->
-        <Style x:Key="SaveButtonStyle"
-         TargetType="Button"
-         BasedOn="{StaticResource {x:Static ui:ThemeKeys.AccentButtonStyleKey}}">
-            <!-- 默认文字色保持白色 -->
-            <Setter Property="Foreground" Value="White"/>
+        <Style x:Key="SaveButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonBackgroundBrush}"/>
             <Style.Triggers>
-                <!-- 鼠标移入时，背景会变浅，我们把文字改成深色 -->
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Foreground" Value="#333333"/>
-                </Trigger>
-                <!-- 如果还想在按下时再调一次样式 -->
-                <Trigger Property="IsPressed" Value="True">
-                    <Setter Property="Foreground" Value="#111111"/>
+                    <Setter Property="Background" Value="{DynamicResource ButtonHoverBrush}"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -40,11 +34,13 @@
                 <ui:NumberBox   MinWidth="60"
                                 Maximum="20" Minimum="4"
                                 PlaceholderText="输入大于4的整数"
-                                SpinButtonPlacementMode="Inline" 
+                                SpinButtonPlacementMode="Inline"
                                 ValidationMode="InvalidInputOverwritten"
                                 IsWrapEnabled="False"
                                 AcceptsExpression="False"
                                 CornerRadius="4,4,4,4"
+                                Background="{DynamicResource InputBackgroundBrush}"
+                                BorderBrush="{DynamicResource InputBorderBrush}"
                                 Value="{Binding RewardThreshold, Mode=TwoWay}"/>
 
             </ui:SettingsCard>
@@ -60,7 +56,9 @@
                 <ComboBox Width="60"
                         SelectedValue="{Binding SelectedThemeOption}"
                         SelectedValuePath="Tag"
-                        Margin="0,8,0,0">
+                        Margin="0,8,0,0"
+                        Background="{DynamicResource InputBackgroundBrush}"
+                        BorderBrush="{DynamicResource InputBorderBrush}">
                     <ComboBoxItem Content="Light"    Tag="{x:Static local:ThemeOption.Light}"   />
                     <ComboBoxItem Content="Dark"     Tag="{x:Static local:ThemeOption.Dark}"    />
                     <ComboBoxItem Content="跟随系统" Tag="{x:Static local:ThemeOption.System}"  />
@@ -76,7 +74,8 @@
                         MinWidth="70"
                         MinHeight="35"
                         Command="{Binding ResetCommand}"
-                        Margin="0,0,0,0"/>
+                        Margin="0,0,0,0"
+                        Style="{StaticResource SaveButtonStyle}"/>
 
                 <!-- 保存：Accent 风格按钮 -->
                 <Button Content="保存"


### PR DESCRIPTION
## Summary
- add `ThemeHelper` utility for applying theme dictionaries
- define full color palette in `LightTheme.xaml` and `DarkTheme.xaml`
- load saved theme at startup using `ThemeHelper`
- style navigation view and settings page with new resource keys
- hook SettingsPageViewModel to use `ThemeHelper`

## Testing
- `dotnet build TimeController.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502772a96c832f9b148ccd585e6de4